### PR TITLE
Fix the concurrent bug of path

### DIFF
--- a/src/main/java/cn/edu/thu/tsfile/timeseries/read/qp/Path.java
+++ b/src/main/java/cn/edu/thu/tsfile/timeseries/read/qp/Path.java
@@ -6,139 +6,171 @@ import cn.edu.thu.tsfile.timeseries.utils.StringContainer;
 /**
  * This class define an Object named Path to represent a series in delta system.
  * And in batch read, this definition is also used in query processing.
- * 
- * @author Kangrong
+ * Note that, Path is unmodified after a new object has been created.
  *
+ * @author Kangrong
  */
 public class Path {
     private String measurement = null;
-    private StringContainer deltaObject = null;
-    private StringContainer fullPath;
+    private String deltaObject = null;
+    private String fullPath;
 
     public Path(StringContainer pathSc) {
+        assert pathSc != null;
         String[] splits = pathSc.toString().split(SystemConstant.PATH_SEPARATER_NO_REGEX);
-        fullPath = new StringContainer(splits, SystemConstant.PATH_SEPARATOR);
+        init(splits);
     }
 
     public Path(String pathSc) {
+        assert pathSc != null;
         String[] splits = pathSc.split(SystemConstant.PATH_SEPARATER_NO_REGEX);
-        fullPath = new StringContainer(splits, SystemConstant.PATH_SEPARATOR);
-
+        init(splits);
     }
 
     public Path(String[] pathSc) {
+        assert pathSc != null;
         String[] splits =
                 new StringContainer(pathSc, SystemConstant.PATH_SEPARATOR).toString().split(
                         SystemConstant.PATH_SEPARATER_NO_REGEX);
-        fullPath = new StringContainer(splits, SystemConstant.PATH_SEPARATOR);
-
+        init(splits);
     }
 
+    private void init(String[] splitedPathArray) {
+        StringContainer sc = new StringContainer(splitedPathArray, SystemConstant.PATH_SEPARATOR);
+        if (sc.size() <= 1) {
+            deltaObject = "";
+            fullPath = measurement = sc.toString();
+        } else {
+            deltaObject = sc.getSubStringContainer(0, -2).toString();
+            measurement = sc.getSubString(-1);
+            fullPath = sc.toString();
+        }
+    }
+
+
     public String getFullPath() {
-        return fullPath.toString();
+        return fullPath;
     }
 
     public String getDeltaObjectToString() {
-        if (deltaObject == null || measurement == null) {
-            separateDeltaObjectMeasurement();
-        }
-        return deltaObject.join(SystemConstant.PATH_SEPARATOR);
+        return deltaObject;
     }
 
     public String getMeasurementToString() {
-        if (deltaObject == null || measurement == null) {
-            separateDeltaObjectMeasurement();
-        }
         return measurement;
     }
 
-    private void separateDeltaObjectMeasurement() {
-        if (fullPath == null || fullPath.size() == 0) {
-            deltaObject = new StringContainer();
-            measurement = "";
-        } else if (fullPath.size() == 1) {
-            deltaObject = new StringContainer();
-            measurement = fullPath.toString();
-        } else {
-            deltaObject = fullPath.getSubStringContainer(0, -2);
-            measurement = fullPath.getSubString(-1);
-        }
+    @Override
+    public int hashCode() {
+        return fullPath.hashCode();
     }
 
-    public static Path mergePath(Path prefix, Path suffix) {
-        Path ret = new Path(prefix.fullPath.clone());
-        ret.fullPath.addTail(suffix.fullPath);
-        return ret;
-    }
-    @Override
-    public int hashCode(){
-    	return fullPath.toString().hashCode();
-    }
-    
     @Override
     public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (!(obj instanceof Path))
-            return false;
-        return this.fullPath.toString().equals(((Path) obj).fullPath.toString());
+        return obj != null && obj instanceof Path && this.fullPath.equals(((Path) obj).fullPath);
     }
 
     public boolean equals(String obj) {
-        if (obj == null)
-            return false;
-        return this.fullPath.toString().equals(obj);
+        return obj != null && this.fullPath.equals(obj);
     }
 
     @Override
     public String toString() {
-        return fullPath.toString();
+        return fullPath;
     }
 
-    public void addHeadPath(String deltaObject) {
-        String[] splits = deltaObject.split(SystemConstant.PATH_SEPARATER_NO_REGEX);
-        fullPath.addHead(splits);
-        deltaObject = null;
-    }
-
-    public void addHeadPath(Path prefix) {
-        fullPath.addHead(prefix.fullPath);
-        deltaObject = null;
-
-    }
 
     @Override
     public Path clone() {
-        StringContainer sc = this.fullPath.clone();
+        return new Path(fullPath);
+    }
+
+    /**
+     * if prefix is null, return false, else judge whether this.fullPath starts with prefix
+     *
+     * @param prefix the prefix string to be tested.
+     * @return True if fullPath starts with prefix
+     */
+    public boolean startWith(String prefix) {
+        return prefix != null && fullPath.startsWith(prefix);
+    }
+
+    /**
+     * if prefix is null, return false, else judge whether this.fullPath starts with prefix.fullPath
+     *
+     * @param prefix the prefix path to be tested.
+     * @return True if fullPath starts with prefix.fullPath
+     */
+    public boolean startWith(Path prefix) {
+        return startWith(prefix.fullPath);
+    }
+
+    public static Path mergePath(Path prefix, Path suffix) {
+        StringContainer sc = new StringContainer(SystemConstant.PATH_SEPARATOR);
+        sc.addTail(prefix);
+        sc.addTail(suffix);
         return new Path(sc);
     }
 
     /**
-     * if prefix is null, return false
-     * 
-     * @param prefix
+     * add {@code prefix}  as the prefix of {@code src}.
+     *
+     * @param src    to be added.
+     * @param prefix the newly prefix
      * @return
      */
-    public boolean startWith(String prefix) {
-        if (prefix == null)
-            return false;
-        return fullPath.toString().startsWith(prefix);
+    public static Path addPrefixPath(Path src, String prefix) {
+        StringContainer sc = new StringContainer(SystemConstant.PATH_SEPARATOR);
+        sc.addTail(prefix);
+        sc.addTail(src);
+        return new Path(sc);
     }
 
-    public boolean startWith(Path prefix) {
-        if (prefix == null)
-            return false;
-        return fullPath.toString().startsWith(prefix.fullPath.toString());
+    /**
+     * add {@code prefix}  as the prefix of {@code src}.
+     *
+     * @param src    to be added.
+     * @param prefix the newly prefix
+     * @return
+     */
+    public static Path addPrefixPath(Path src, Path prefix) {
+        return addPrefixPath(src, prefix.fullPath);
     }
 
-    public void replace(String srcPrefix, Path descPrefix) {
-        if (!startWith(srcPrefix))
-            return;
+    /**
+     * replace prefix of descPrefix with given parameter {@code srcPrefix}.
+     * If the level of the path constructed by {@code srcPrefix} is larger than {@code descPrefix}, return {@code
+     * srcPrefix} directly.
+     *
+     * @param srcPrefix  the prefix to replace descPrefix
+     * @param descPrefix to be replaced
+     * @return If the level of the path constructed by {@code srcPrefix} is larger than {@code descPrefix}, return
+     * {@code srcPrefix} directly.
+     */
+    public static Path replace(String srcPrefix, Path descPrefix) {
+        if ("".equals(srcPrefix) || descPrefix.startWith(srcPrefix))
+            return descPrefix;
         int prefixSize = srcPrefix.split(SystemConstant.PATH_SEPARATER_NO_REGEX).length;
-        StringContainer newPath = fullPath.getSubStringContainer(prefixSize, -1);
-        newPath.addHead(descPrefix.fullPath);
-        this.fullPath = newPath;
-        deltaObject = null;
+        String[] descArray = descPrefix.fullPath.split(SystemConstant.PATH_SEPARATER_NO_REGEX);
+        if (descArray.length <= prefixSize)
+            return new Path(srcPrefix);
+        StringContainer sc = new StringContainer(SystemConstant.PATH_SEPARATOR);
+        sc.addTail(srcPrefix);
+        for (int i = prefixSize; i < descArray.length; i++) {
+            sc.addTail(descArray[i]);
+        }
+        return new Path(sc);
     }
 
+    /**
+     * replace prefix of {@code descPrefix} with given parameter {@code srcPrefix}.
+     * If the level of {@code srcPrefix} is larger than {@code descPrefix}, return {@code srcPrefix} directly.
+     *
+     * @param srcPrefix  the prefix to replace descPrefix
+     * @param descPrefix to be replaced
+     * @return If the level of {@code srcPrefix} is larger than {@code descPrefix}, return {@code srcPrefix} directly.
+     */
+    public static Path replace(Path srcPrefix, Path descPrefix) {
+        return replace(srcPrefix.fullPath, descPrefix);
+    }
 }

--- a/src/main/java/cn/edu/thu/tsfile/timeseries/utils/StringContainer.java
+++ b/src/main/java/cn/edu/thu/tsfile/timeseries/utils/StringContainer.java
@@ -4,66 +4,65 @@ import java.util.ArrayList;
 
 /**
  * this class is used to contact String effectively.It contains a StringBuider
- * and initialize it until {@code toString} is called.<br>
+ * and initialize it until {@code toString} is called.
  * Note:it's not thread safety
- * 
- * @author kangrong
  *
+ * @author kangrong
  */
 public class StringContainer {
-	private StringBuilder stringBuilder;
-	private ArrayList<String> sequenceList;
-	private ArrayList<String> reverseList;
-	/**
-	 * the summation length of all string segments
-	 */
-	private int totalLength = 0;
-	/**
+    // while call toString, all substrings are jointed with joinSeparator
+    private final String joinSeparator;
+    private StringBuilder stringBuilder;
+    private ArrayList<String> sequenceList;
+    private ArrayList<String> reverseList;
+    /**
+     * the summation length of all string segments
+     */
+    private int totalLength = 0;
+    /**
      * the count of string segments
      */
-	private int count = 0;
-	private boolean isUpdated = true;
-	private String cache;
-	// while call toString, all substrings are jointed with joinSeparator
-	private final String joinSeparator;
+    private int count = 0;
+    private boolean isUpdated = true;
+    private String cache;
 
-	public StringContainer() {
-		sequenceList = new ArrayList<String>();
-		reverseList = new ArrayList<String>();
-		joinSeparator = null;
-	}
+    public StringContainer() {
+        sequenceList = new ArrayList<>();
+        reverseList = new ArrayList<>();
+        joinSeparator = null;
+    }
 
-	public StringContainer(String joinSeparator) {
-		sequenceList = new ArrayList<String>();
-		reverseList = new ArrayList<String>();
-		this.joinSeparator = joinSeparator;
-	}
+    public StringContainer(String joinSeparator) {
+        sequenceList = new ArrayList<>();
+        reverseList = new ArrayList<>();
+        this.joinSeparator = joinSeparator;
+    }
 
-	public StringContainer(String[] strings) {
-		this();
-		addTail(strings);
-	}
+    public StringContainer(String[] strings) {
+        this();
+        addTail(strings);
+    }
 
-	public StringContainer(String[] strings, String joinSeparator) {
-		this(joinSeparator);
-		addTail(strings);
-	}
+    public StringContainer(String[] strings, String joinSeparator) {
+        this(joinSeparator);
+        addTail(strings);
+    }
 
-	public int size() {
-		return count;
-	}
+    public int size() {
+        return count;
+    }
 
-	public int length() {
-		return totalLength;
-	}
+    public int length() {
+        return totalLength;
+    }
 
-	public ArrayList<String> getSequenceList() {
-		return sequenceList;
-	}
+    public ArrayList<String> getSequenceList() {
+        return sequenceList;
+    }
 
-	public ArrayList<String> getReverseList() {
-		return reverseList;
-	}
+    public ArrayList<String> getReverseList() {
+        return reverseList;
+    }
 
     public StringContainer addTail(Object... objs) {
         isUpdated = true;
@@ -76,274 +75,268 @@ public class StringContainer {
         return this;
     }
 
-	/**
-	 * add a Strings array at this container's tail.<br>
-	 * strings:"a","b","c",<br>
-	 * StringContainer this:["d","e","f"],<br>
-	 * result:this:["d","e","f","a","b","c"],<br>
-	 * 
-	 * @param strings
-	 *            - to be added
-	 * @return - this object
-	 */
-	public StringContainer addTail(String... strings) {
-		isUpdated = true;
-		count += strings.length;
-		for (int i = 0; i < strings.length; i++) {
-			totalLength += strings[i].length();
-			sequenceList.add(strings[i]);
-		}
-		return this;
-	}
+    /**
+     * add a Strings array at this container's tail.<br>
+     * strings:"a","b","c",<br>
+     * StringContainer this:["d","e","f"],<br>
+     * result:this:["d","e","f","a","b","c"],<br>
+     *
+     * @param strings - to be added
+     * @return - this object
+     */
+    public StringContainer addTail(String... strings) {
+        isUpdated = true;
+        count += strings.length;
+        for (int i = 0; i < strings.length; i++) {
+            totalLength += strings[i].length();
+            sequenceList.add(strings[i]);
+        }
+        return this;
+    }
 
-	/**
-	 * add a StringContainer at this container's tail.<br>
-	 * param StringContainer:["a","b","c"],<br>
-	 * this StringContainer :["d","e","f"],<br>
-	 * result:this:["d","e","f","a","b","c"],<br>
-	 * 
-	 * @param mContainer
-	 *            - to be added
-	 * @return - this object
-	 */
-	public StringContainer addTail(StringContainer mContainer) {
-		isUpdated = true;
-		ArrayList<String> mSeqList = mContainer.getSequenceList();
-		ArrayList<String> mRevList = mContainer.getReverseList();
-		count += mRevList.size() + mSeqList.size();
-		String temp;
-		for (int i = mRevList.size() - 1; i >= 0; i--) {
-			temp = mRevList.get(i);
-			sequenceList.add(temp);
-			totalLength += temp.length();
-		}
-		for (int i = 0; i < mSeqList.size(); i++) {
-			temp = mSeqList.get(i);
-			sequenceList.add(temp);
-			totalLength += temp.length();
-		}
-		return this;
-	}
+    /**
+     * add a StringContainer at this container's tail.<br>
+     * param StringContainer:["a","b","c"],<br>
+     * this StringContainer :["d","e","f"],<br>
+     * result:this:["d","e","f","a","b","c"],<br>
+     *
+     * @param mContainer - to be added
+     * @return - this object
+     */
+    public StringContainer addTail(StringContainer mContainer) {
+        isUpdated = true;
+        ArrayList<String> mSeqList = mContainer.getSequenceList();
+        ArrayList<String> mRevList = mContainer.getReverseList();
+        count += mRevList.size() + mSeqList.size();
+        String temp;
+        for (int i = mRevList.size() - 1; i >= 0; i--) {
+            temp = mRevList.get(i);
+            sequenceList.add(temp);
+            totalLength += temp.length();
+        }
+        for (int i = 0; i < mSeqList.size(); i++) {
+            temp = mSeqList.get(i);
+            sequenceList.add(temp);
+            totalLength += temp.length();
+        }
+        return this;
+    }
 
-	/**
-	 * add a Strings array from this container's header.<br>
-	 * strings:"a","b","c",<br>
-	 * StringContainer this:["d","e","f"],<br>
-	 * result:this:["a","b","c","d","e","f"],<br>
-	 * 
-	 * @param strings
-	 *            - to be added
-	 * @return - this object
-	 */
-	public StringContainer addHead(String... strings) {
-		isUpdated = true;
-		count += strings.length;
-		for (int i = strings.length - 1; i >= 0; i--) {
-			totalLength += strings[i].length();
-			reverseList.add(strings[i]);
-		}
-		return this;
-	}
+    /**
+     * add a Strings array from this container's header.<br>
+     * strings:"a","b","c",<br>
+     * StringContainer this:["d","e","f"],<br>
+     * result:this:["a","b","c","d","e","f"],<br>
+     *
+     * @param strings - to be added
+     * @return - this object
+     */
+    public StringContainer addHead(String... strings) {
+        isUpdated = true;
+        count += strings.length;
+        for (int i = strings.length - 1; i >= 0; i--) {
+            totalLength += strings[i].length();
+            reverseList.add(strings[i]);
+        }
+        return this;
+    }
 
-	/**
-	 * add a StringContainer from this container's header.<br>
-	 * StringContainer m:["a","b","c"],<br>
-	 * StringContainer this:["d","e","f"],<br>
-	 * result:this:["a","b","c","d","e","f"],<br>
-	 * 
-	 * @param mContainer
-	 *            - given StringContainer to be add in head
-	 * @return - this object
-	 */
-	public StringContainer addHead(StringContainer mContainer) {
-		isUpdated = true;
-		ArrayList<String> mSeqList = mContainer.getSequenceList();
-		ArrayList<String> mRevList = mContainer.getReverseList();
-		count += mRevList.size() + mSeqList.size();
-		String temp;
-		for (int i = mSeqList.size() - 1; i >= 0; i--) {
-			temp = mSeqList.get(i);
-			reverseList.add(temp);
-			totalLength += temp.length();
-		}
-		for (int i = 0; i < mRevList.size(); i++) {
-			temp = mRevList.get(i);
-			reverseList.add(temp);
-			totalLength += temp.length();
-		}
-		return this;
-	}
+    /**
+     * add a StringContainer from this container's header.<br>
+     * StringContainer m:["a","b","c"],<br>
+     * StringContainer this:["d","e","f"],<br>
+     * result:this:["a","b","c","d","e","f"],<br>
+     *
+     * @param mContainer - given StringContainer to be add in head
+     * @return - this object
+     */
+    public StringContainer addHead(StringContainer mContainer) {
+        isUpdated = true;
+        ArrayList<String> mSeqList = mContainer.getSequenceList();
+        ArrayList<String> mRevList = mContainer.getReverseList();
+        count += mRevList.size() + mSeqList.size();
+        String temp;
+        for (int i = mSeqList.size() - 1; i >= 0; i--) {
+            temp = mSeqList.get(i);
+            reverseList.add(temp);
+            totalLength += temp.length();
+        }
+        for (int i = 0; i < mRevList.size(); i++) {
+            temp = mRevList.get(i);
+            reverseList.add(temp);
+            totalLength += temp.length();
+        }
+        return this;
+    }
 
-	@Override
-	public String toString() {
-		if (!isUpdated)
-			return cache;
-		if (totalLength <= 0)
-			return "";
-		if (joinSeparator == null) {
-			stringBuilder = new StringBuilder(totalLength);
-			for (int i = reverseList.size() - 1; i >= 0; i--) {
-				stringBuilder.append(reverseList.get(i));
-			}
-			for (int i = 0; i < sequenceList.size(); i++) {
-				stringBuilder.append(sequenceList.get(i));
-			}
-			cache = stringBuilder.toString();
-		} else {
-			cache = join(joinSeparator);
-		}
-		isUpdated = false;
-		return cache;
-	}
+    @Override
+    public String toString() {
+        if (!isUpdated)
+            return cache;
+        if (totalLength <= 0)
+            return "";
+        if (joinSeparator == null) {
+            stringBuilder = new StringBuilder(totalLength);
+            for (int i = reverseList.size() - 1; i >= 0; i--) {
+                stringBuilder.append(reverseList.get(i));
+            }
+            for (int i = 0; i < sequenceList.size(); i++) {
+                stringBuilder.append(sequenceList.get(i));
+            }
+            cache = stringBuilder.toString();
+        } else {
+            cache = join(joinSeparator);
+        }
+        isUpdated = false;
+        return cache;
+    }
 
-	/**
-	 * for all string in rev and seq, concat them with separator and return
-	 * String
-	 * 
-	 * @param separator
-	 * @return - result joined in type of String with parameter
-	 */
-	public String join(String separator) {
-		if (totalLength <= 0)
-			return "";
-		stringBuilder = new StringBuilder(totalLength + (count-1)
-				* separator.length());
-		for (int i = reverseList.size() - 1; i >= 1; i--) {
-			stringBuilder.append(reverseList.get(i));
-			stringBuilder.append(separator);
-		}
-		if (!reverseList.isEmpty()) {
-			stringBuilder.append(reverseList.get(0));
-			if (!sequenceList.isEmpty())
-				stringBuilder.append(separator);
-		}
-		int i;
-		for (i = 0; i < sequenceList.size() - 1; i++) {
-			stringBuilder.append(sequenceList.get(i));
-			stringBuilder.append(separator);
-		}
-		if (!sequenceList.isEmpty())
-			stringBuilder.append(sequenceList.get(i));
-		return stringBuilder.toString();
-	}
+    /**
+     * for all string in rev and seq, concat them with separator and return
+     * String
+     *
+     * @param separator
+     * @return - result joined in type of String with parameter
+     */
+    public String join(String separator) {
+        if (totalLength <= 0)
+            return "";
+        stringBuilder = new StringBuilder(totalLength + (count - 1)
+                * separator.length());
+        for (int i = reverseList.size() - 1; i >= 1; i--) {
+            stringBuilder.append(reverseList.get(i));
+            stringBuilder.append(separator);
+        }
+        if (!reverseList.isEmpty()) {
+            stringBuilder.append(reverseList.get(0));
+            if (!sequenceList.isEmpty())
+                stringBuilder.append(separator);
+        }
+        int i;
+        for (i = 0; i < sequenceList.size() - 1; i++) {
+            stringBuilder.append(sequenceList.get(i));
+            stringBuilder.append(separator);
+        }
+        if (!sequenceList.isEmpty())
+            stringBuilder.append(sequenceList.get(i));
+        return stringBuilder.toString();
+    }
 
-	/**
-	 * return a sub-string in this container.<br>
-	 * e.g. this container is ["aa","bbb","cc","d","ee"]; this.getSubString(0) =
-	 * "a";this.getSubString(2) = "c";this.getSubString(-1) = "ee";
-	 * 
-	 * @param index
-	 *            - the index of wanted sub-string
-	 * @return - substring result
-	 */
-	public String getSubString(int index) {
-		int realIndex = index >= 0 ? index : count + index;
-		if (realIndex < 0 || realIndex >= count)
-			throw new IndexOutOfBoundsException("Index: " + index
-					+ ", Real Index: " + realIndex + ", Size: " + count);
-		if (realIndex < reverseList.size()) {
-			return reverseList.get(reverseList.size() - 1 - realIndex);
-		} else {
-			return sequenceList.get(realIndex - reverseList.size());
-		}
-	}
+    /**
+     * return a sub-string in this container.<br>
+     * e.g. this container is ["aa","bbb","cc","d","ee"]; this.getSubString(0) =
+     * "a";this.getSubString(2) = "c";this.getSubString(-1) = "ee";
+     *
+     * @param index - the index of wanted sub-string
+     * @return - substring result
+     */
+    public String getSubString(int index) {
+        int realIndex = index >= 0 ? index : count + index;
+        if (realIndex < 0 || realIndex >= count)
+            throw new IndexOutOfBoundsException("Index: " + index
+                    + ", Real Index: " + realIndex + ", Size: " + count);
+        if (realIndex < reverseList.size()) {
+            return reverseList.get(reverseList.size() - 1 - realIndex);
+        } else {
+            return sequenceList.get(realIndex - reverseList.size());
+        }
+    }
 
-	/**
-	 * /** return a sub-container consist of several continuous strings in this
-	 * container.If start <= end, return a empty container<br>
-	 * e.g. this container is ["aa","bbb","cc","d","ee"]; <br>
-	 * this.getSubString(0,0) = ["aa"]<br>
-	 * this.getSubString(1,3) = ["bbb","cc","d"]<br>
-	 * this.getSubString(1,-1) = ["bbb","cc","d", "ee"]<br>
-	 * 
-	 * @param start
-	 *            - the start index of wanted sub-string
-	 * @param end
-	 *            - the end index of wanted sub-string
-	 * @return - substring result
-	 */
-	public StringContainer getSubStringContainer(int start, int end) {
-		int realStartIndex = start >= 0 ? start : count + start;
-		int realEndIndex = end >= 0 ? end : count + end;
-		if (realStartIndex < 0 || realStartIndex >= count)
-			throw new IndexOutOfBoundsException("start Index: " + start
-					+ ", Real start Index: " + realStartIndex + ", Size: "
-					+ count);
-		if (realEndIndex < 0 || realEndIndex >= count)
-			throw new IndexOutOfBoundsException("end Index: " + end
-					+ ", Real end Index: " + realEndIndex + ", Size: " + count);
-		StringContainer ret = new StringContainer();
-		if (realStartIndex < reverseList.size()) {
-			for (int i = reverseList.size() - 1 - realStartIndex; i >= Math
-					.max(0, reverseList.size() - 1 - realEndIndex); i--) {
-				ret.addTail(this.reverseList.get(i));
-			}
-		}
-		if (realEndIndex >= reverseList.size()) {
-			for (int i = Math.max(0, realStartIndex - reverseList.size()); i <= realEndIndex
-					- reverseList.size(); i++) {
-				ret.addTail(this.sequenceList.get(i));
-			}
-		}
-		return ret;
-	}
+    /**
+     * /** return a sub-container consist of several continuous strings in this
+     * {@code container.If start <= end, return a empty container}
+     * e.g. this container is ["aa","bbb","cc","d","ee"];
+     * this.getSubString(0,0) = ["aa"]<br>
+     * this.getSubString(1,3) = ["bbb","cc","d"]<br>
+     * this.getSubString(1,-1) = ["bbb","cc","d", "ee"]<br>
+     *
+     * @param start - the start index of wanted sub-string
+     * @param end   - the end index of wanted sub-string
+     * @return - substring result
+     */
+    public StringContainer getSubStringContainer(int start, int end) {
+        int realStartIndex = start >= 0 ? start : count + start;
+        int realEndIndex = end >= 0 ? end : count + end;
+        if (realStartIndex < 0 || realStartIndex >= count)
+            throw new IndexOutOfBoundsException("start Index: " + start
+                    + ", Real start Index: " + realStartIndex + ", Size: "
+                    + count);
+        if (realEndIndex < 0 || realEndIndex >= count)
+            throw new IndexOutOfBoundsException("end Index: " + end
+                    + ", Real end Index: " + realEndIndex + ", Size: " + count);
+        StringContainer ret = new StringContainer(joinSeparator);
+        if (realStartIndex < reverseList.size()) {
+            for (int i = reverseList.size() - 1 - realStartIndex; i >= Math
+                    .max(0, reverseList.size() - 1 - realEndIndex); i--) {
+                ret.addTail(this.reverseList.get(i));
+            }
+        }
+        if (realEndIndex >= reverseList.size()) {
+            for (int i = Math.max(0, realStartIndex - reverseList.size()); i <= realEndIndex
+                    - reverseList.size(); i++) {
+                ret.addTail(this.sequenceList.get(i));
+            }
+        }
+        return ret;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-	    int result = 1;
-	    if(joinSeparator != null)
-	    	result = prime*result+joinSeparator.hashCode();
-	    for (String string : reverseList) {
-	    	result = prime * result + ((string == null) ? 0 : string.hashCode());
-		}
-	    for (String string : sequenceList) {
-	    	result = prime * result + ((string == null) ? 0 : string.hashCode());
-		}
-	    return result;
-	}
-	@Override
-	public boolean equals(Object sc) {
-		return this.equals((StringContainer) sc);
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        if (joinSeparator != null)
+            result = prime * result + joinSeparator.hashCode();
+        for (String string : reverseList) {
+            result = prime * result + ((string == null) ? 0 : string.hashCode());
+        }
+        for (String string : sequenceList) {
+            result = prime * result + ((string == null) ? 0 : string.hashCode());
+        }
+        return result;
+    }
 
-	public boolean equals(StringContainer sc) {
-		if (sc == this)
-			return true;
-		if (count != sc.count)
-			return false;
-		if (totalLength != sc.totalLength)
-			return false;
-		if (!joinSeparator.equals(sc.joinSeparator))
-			return false;
-		if (sequenceList.size() != sc.sequenceList.size())
-			return false;
-		for (int i = 0; i < sequenceList.size(); i++) {
-			if (!sequenceList.get(i).equals(sc.sequenceList.get(i)))
-				return false;
-		}
-		if (reverseList.size() != sc.reverseList.size())
-			return false;
-		for (int i = 0; i < reverseList.size(); i++) {
-			if (!reverseList.get(i).equals(sc.reverseList.get(i)))
-				return false;
-		}
-		return true;
-	}
+    @Override
+    public boolean equals(Object sc) {
+        return this.equals((StringContainer) sc);
+    }
 
-	@Override
-	public StringContainer clone() {
-		StringContainer ret = new StringContainer(joinSeparator);
-		for (String s : sequenceList) {
-			ret.sequenceList.add(s);
-		}
-		for (String s : reverseList) {
-			ret.reverseList.add(s);
-		}
-		ret.totalLength = totalLength;
-		ret.count = count;
-		ret.isUpdated = isUpdated;
-		ret.cache = cache;
-		return ret;
-	}
+    public boolean equals(StringContainer sc) {
+        if (sc == this)
+            return true;
+        if (count != sc.count)
+            return false;
+        if (totalLength != sc.totalLength)
+            return false;
+        if (!joinSeparator.equals(sc.joinSeparator))
+            return false;
+        if (sequenceList.size() != sc.sequenceList.size())
+            return false;
+        for (int i = 0; i < sequenceList.size(); i++) {
+            if (!sequenceList.get(i).equals(sc.sequenceList.get(i)))
+                return false;
+        }
+        if (reverseList.size() != sc.reverseList.size())
+            return false;
+        for (int i = 0; i < reverseList.size(); i++) {
+            if (!reverseList.get(i).equals(sc.reverseList.get(i)))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public StringContainer clone() {
+        StringContainer ret = new StringContainer(joinSeparator);
+        for (String s : sequenceList) {
+            ret.sequenceList.add(s);
+        }
+        for (String s : reverseList) {
+            ret.reverseList.add(s);
+        }
+        ret.totalLength = totalLength;
+        ret.count = count;
+        ret.isUpdated = isUpdated;
+        ret.cache = cache;
+        return ret;
+    }
 }

--- a/src/test/java/cn/edu/thu/tsfile/timeseries/read/qp/PathTest.java
+++ b/src/test/java/cn/edu/thu/tsfile/timeseries/read/qp/PathTest.java
@@ -1,0 +1,63 @@
+package cn.edu.thu.tsfile.timeseries.read.qp;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PathTest {
+    private void testPath(Path path, String device, String measurement, String full) {
+        assertEquals(device, path.getDeltaObjectToString());
+        assertEquals(measurement, path.getMeasurementToString());
+        assertEquals(full, path.getFullPath());
+    }
+
+    @Test
+    public void construct() throws Exception {
+        Path path = new Path("a.b.c");
+        testPath(path, "a.b", "c", "a.b.c");
+        path = new Path("c");
+        testPath(path, "", "c", "c");
+        path = new Path("");
+        testPath(path, "", "", "");
+    }
+
+    @Test
+    public void startWith() throws Exception {
+        Path path = new Path("a.b.c");
+        assertTrue(path.startWith(new Path("")));
+        assertTrue(path.startWith(new Path("a")));
+        assertTrue(path.startWith(new Path("a.b.c")));
+    }
+
+    @Test
+    public void mergePath() throws Exception {
+        Path prefix = new Path("a.b.c");
+        Path suffix = new Path("d.e");
+        Path suffix1 = new Path("");
+        testPath(Path.mergePath(prefix, suffix), "a.b.c.d", "e", "a.b.c.d.e");
+        testPath(Path.mergePath(prefix, suffix1), "a.b", "c", "a.b.c");
+    }
+
+    @Test
+    public void addHeadPath() throws Exception {
+        Path desc = new Path("a.b.c");
+        Path head = new Path("d.e");
+        Path head1 = new Path("");
+        testPath(Path.addPrefixPath(desc, head), "d.e.a.b", "c", "d.e.a.b.c");
+        testPath(Path.mergePath(desc, head1), "a.b", "c", "a.b.c");
+    }
+
+    @Test
+    public void replace() throws Exception {
+        Path src = new Path("a.b.c");
+        Path rep1 = new Path("");
+        Path rep2 = new Path("d");
+        Path rep3 = new Path("d.e.f");
+        Path rep4 = new Path("d.e.f.g");
+        testPath(Path.replace(rep1,src), "a.b", "c", "a.b.c");
+        testPath(Path.replace(rep2,src), "d.b", "c", "d.b.c");
+        testPath(Path.replace(rep3,src), "d.e", "f", "d.e.f");
+        testPath(Path.replace(rep4,src), "d.e.f", "g", "d.e.f.g");
+    }
+
+}


### PR DESCRIPTION
The primary `Path` is not synchronized, it may cause unexpected concurrent error. 
In this pr, `Path` is changed to be unmodified after it has been constructed.
Primary functions like `replace`, `addHead` .etc are changed to static functions.

JUnit test case of `Path` is added.

A bug in `StringContainer.getSubStringContainer` is also fixed.