### PR TITLE
fix bug : Check measurement id before adding it into the fileSchema of a TsFile

### DIFF
--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/write/schema/FileSchema.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/write/schema/FileSchema.java
@@ -5,6 +5,7 @@ import cn.edu.tsinghua.tsfile.file.metadata.enums.TSDataType;
 import cn.edu.tsinghua.tsfile.timeseries.write.InternalRecordWriter;
 import cn.edu.tsinghua.tsfile.timeseries.write.desc.MeasurementDescriptor;
 import cn.edu.tsinghua.tsfile.timeseries.write.exception.InvalidJsonSchemaException;
+import cn.edu.tsinghua.tsfile.timeseries.write.exception.WriteProcessException;
 import cn.edu.tsinghua.tsfile.timeseries.write.schema.converter.JsonConverter;
 import cn.edu.tsinghua.tsfile.timeseries.write.series.IRowGroupWriter;
 import org.json.JSONObject;
@@ -51,7 +52,7 @@ public class FileSchema {
 
     }
 
-    public FileSchema(JSONObject jsonSchema) throws InvalidJsonSchemaException {
+    public FileSchema(JSONObject jsonSchema) throws WriteProcessException {
         JsonConverter.converterJsonToSchema(jsonSchema, this);
     }
 
@@ -188,5 +189,9 @@ public class FileSchema {
             }
         }
         appearDeltaObjectIdSet.clear();
+    }
+
+    public boolean hasMeasurement(String measurementId) {
+        return descriptorMap.containsKey(measurementId);
     }
 }

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/write/WriteTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/write/WriteTest.java
@@ -30,6 +30,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Random;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -200,6 +202,14 @@ public class WriteTest {
                 innerWriter.write(record);
             }
             lineCount++;
+        }
+        //test duplicate measurement adding
+        JSONObject dupMeasure = (JSONObject) measurementArray.get(measurementArray.length() - 1);
+        try {
+            innerWriter.addMeasurementByJson(dupMeasure);
+        }catch (WriteProcessException e){
+            assertEquals("given measurement has exists! "+
+                    dupMeasure.getString(JsonFormatConstant.MEASUREMENT_UID), e.getMessage());
         }
         try {
             innerWriter.close();


### PR DESCRIPTION
A measurement is not allowed to add into a TsFile If the TsFile already has a measurement with the same name.
This pull request adds the prechecking.