### PR TITLE
Add empty timearray in DynamicOneColumnData

### DIFF
--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/basis/TsFile.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/basis/TsFile.java
@@ -3,7 +3,6 @@ package cn.edu.tsinghua.tsfile.timeseries.basis;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +17,7 @@ import cn.edu.tsinghua.tsfile.timeseries.filter.definition.FilterExpression;
 import cn.edu.tsinghua.tsfile.timeseries.filter.definition.FilterFactory;
 import cn.edu.tsinghua.tsfile.timeseries.filter.definition.SingleSeriesFilterExpression;
 import cn.edu.tsinghua.tsfile.timeseries.read.management.SeriesSchema;
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryDataSet;
 import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryEngine;
 import cn.edu.tsinghua.tsfile.timeseries.utils.RecordUtils;

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/definition/operators/NoFilter.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/definition/operators/NoFilter.java
@@ -1,0 +1,33 @@
+package cn.edu.tsinghua.tsfile.timeseries.filter.definition.operators;
+
+import cn.edu.tsinghua.tsfile.timeseries.filter.definition.SingleSeriesFilterExpression;
+import cn.edu.tsinghua.tsfile.timeseries.filter.definition.filterseries.FilterSeries;
+import cn.edu.tsinghua.tsfile.timeseries.filter.visitorImpl.FilterVisitor;
+
+/**
+ * <code>NoFilter</code> means that there is no filter.
+ */
+public class NoFilter extends SingleSeriesFilterExpression{
+    private static NoFilter noFilter;
+
+    private static class SingletonHolder {
+        private static final NoFilter INSTANCE = new NoFilter();
+    }
+
+    private NoFilter() {
+    }
+
+    public static final NoFilter getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
+    @Override
+    public <T> T accept(FilterVisitor<T> visitor) {
+        return null;
+    }
+
+    @Override
+    public FilterSeries<?> getFilterSeries() {
+        return null;
+    }
+}

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/DoubleFilterVerifier.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/DoubleFilterVerifier.java
@@ -132,6 +132,16 @@ public class DoubleFilterVerifier extends FilterVerifier implements FilterVisito
         return union(visit(or.getLeft()), visit(or.getRight()));
     }
 
+    @Override
+    public DoubleInterval visit(NoFilter noFilter) {
+        DoubleInterval ans = new DoubleInterval();
+        ans.v[0] = Double.MIN_VALUE;
+        ans.flag[0] = true;
+        ans.v[1] = Double.MAX_VALUE;
+        ans.flag[1] = true;
+        return ans;
+    }
+
     private DoubleInterval intersection(DoubleInterval left, DoubleInterval right) {
         DoubleInterval ans = new DoubleInterval();
         DoubleInterval partResult = new DoubleInterval();

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/FloatFilterVerifier.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/FloatFilterVerifier.java
@@ -132,6 +132,16 @@ public class FloatFilterVerifier extends FilterVerifier implements FilterVisitor
         return union(visit(or.getLeft()), visit(or.getRight()));
     }
 
+    @Override
+    public FloatInterval visit(NoFilter noFilter) {
+        FloatInterval ans = new FloatInterval();
+        ans.v[0] = Float.MIN_VALUE;
+        ans.flag[0] = true;
+        ans.v[1] = Float.MAX_VALUE;
+        ans.flag[1] = true;
+        return ans;
+    }
+
     public FloatInterval intersection(FloatInterval left, FloatInterval right) {
         FloatInterval ans = new FloatInterval();
         FloatInterval partResult = new FloatInterval();

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/IntFilterVerifier.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/IntFilterVerifier.java
@@ -134,6 +134,16 @@ public class IntFilterVerifier extends FilterVerifier implements FilterVisitor<I
         return union(visit(or.getLeft()), visit(or.getRight()));
     }
 
+    @Override
+    public IntInterval visit(NoFilter noFilter) {
+        IntInterval ans = new IntInterval();
+        ans.v[0] = Integer.MIN_VALUE;
+        ans.flag[0] = true;
+        ans.v[1] = Integer.MAX_VALUE;
+        ans.flag[1] = true;
+        return ans;
+    }
+
     private IntInterval intersection(IntInterval left, IntInterval right) {
         IntInterval ans = new IntInterval();
         IntInterval partResult = new IntInterval();

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/LongFilterVerifier.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/verifier/LongFilterVerifier.java
@@ -131,6 +131,16 @@ public class LongFilterVerifier extends FilterVerifier implements FilterVisitor<
         return union(visit(or.getLeft()), visit(or.getRight()));
     }
 
+    @Override
+    public LongInterval visit(NoFilter noFilter) {
+        LongInterval ans = new LongInterval();
+        ans.v[0] = Long.MIN_VALUE;
+        ans.flag[0] = true;
+        ans.v[1] = Long.MAX_VALUE;
+        ans.flag[1] = true;
+        return ans;
+    }
+
     private LongInterval intersection(LongInterval left, LongInterval right) {
         LongInterval ans = new LongInterval();
         LongInterval partResult = new LongInterval();

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/ConvertExpressionVisitor.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/ConvertExpressionVisitor.java
@@ -50,6 +50,11 @@ public class ConvertExpressionVisitor implements FilterVisitor<FilterExpression>
     }
 
     @Override
+    public FilterExpression visit(NoFilter noFilter) {
+        return noFilter;
+    }
+
+    @Override
     public FilterExpression visit(Not not) {
         return invertor.invert(not.getFilterExpression());
     }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/DigestVisitor.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/DigestVisitor.java
@@ -120,4 +120,9 @@ public class DigestVisitor implements FilterVisitor<Boolean> {
         return satisfy(digest, or.getLeft()) || satisfy(digest, or.getRight());
     }
 
+    @Override
+    public Boolean visit(NoFilter noFilter) {
+        return true;
+    }
+
 }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/FilterVisitor.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/FilterVisitor.java
@@ -27,4 +27,5 @@ public interface FilterVisitor<R> {
 
     R visit(Or or);
 
+    R visit(NoFilter noFilter);
 }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/InvertExpressionVisitor.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/InvertExpressionVisitor.java
@@ -57,6 +57,11 @@ public class InvertExpressionVisitor implements FilterVisitor<FilterExpression> 
     }
 
     @Override
+    public FilterExpression visit(NoFilter noFilter) {
+        return null;
+    }
+
+    @Override
     public SingleSeriesFilterExpression visit(Not not) {
         return not.getFilterExpression();
     }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/OverflowTimeFilter.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/OverflowTimeFilter.java
@@ -65,4 +65,9 @@ public class OverflowTimeFilter implements FilterVisitor<Boolean> {
         return satisfy(or.getLeft(), startTime, endTime) || satisfy(or.getRight(), startTime, endTime);
     }
 
+    @Override
+    public Boolean visit(NoFilter noFilter) {
+        return true;
+    }
+
 }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/SingleValueVisitor.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/SingleValueVisitor.java
@@ -22,14 +22,14 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
     private static final Logger LOG = LoggerFactory.getLogger(SingleValueVisitor.class);
     private V value;
     private FilterVerifier verifier;
-    private SingleSeriesFilterExpression ssfilter;
+    private SingleSeriesFilterExpression ssFilter;
 
     public SingleValueVisitor() {
     }
 
     public SingleValueVisitor(SingleSeriesFilterExpression filter) {
         verifier = FilterVerifier.create(filter.getFilterSeries().getSeriesDataType());
-        this.ssfilter = filter;
+        this.ssFilter = filter;
     }
 
     private Boolean satisfy(V value, SingleSeriesFilterExpression filter) {
@@ -44,7 +44,7 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
      * @return is satisfied
      */
     public boolean verify(int value) {
-        IntInterval val = (IntInterval) verifier.getInterval(ssfilter);
+        IntInterval val = (IntInterval) verifier.getInterval(ssFilter);
         for (int i = 0; i < val.count; i += 2) {
             if (val.v[i] < value && value < val.v[i + 1])
                 return true;
@@ -57,7 +57,7 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
     }
 
     public boolean verify(long value) {
-        LongInterval val = (LongInterval) verifier.getInterval(ssfilter);
+        LongInterval val = (LongInterval) verifier.getInterval(ssFilter);
         for (int i = 0; i < val.count; i += 2) {
             if (val.v[i] < value && value < val.v[i + 1])
                 return true;
@@ -70,7 +70,7 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
     }
 
     public boolean verify(float value) {
-        FloatInterval val = (FloatInterval) verifier.getInterval(ssfilter);
+        FloatInterval val = (FloatInterval) verifier.getInterval(ssFilter);
         for (int i = 0; i < val.count; i += 2) {
             if (val.v[i] < value && value < val.v[i + 1])
                 return true;
@@ -83,7 +83,7 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
     }
 
     public boolean verify(double value) {
-        DoubleInterval val = (DoubleInterval) verifier.getInterval(ssfilter);
+        DoubleInterval val = (DoubleInterval) verifier.getInterval(ssFilter);
         for (int i = 0; i < val.count; i += 2) {
             if (val.v[i] < value && value < val.v[i + 1])
                 return true;
@@ -154,6 +154,11 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
     @Override
     public Boolean visit(Or or) {
         return satisfy(value, or.getLeft()) || satisfy(value, or.getRight());
+    }
+
+    @Override
+    public Boolean visit(NoFilter noFilter) {
+        return true;
     }
 
 }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/SingleValueVisitor.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/filter/visitorImpl/SingleValueVisitor.java
@@ -32,7 +32,7 @@ public class SingleValueVisitor<V extends Comparable<V>> implements FilterVisito
         this.ssfilter = filter;
     }
 
-    public Boolean satisfy(V value, SingleSeriesFilterExpression filter) {
+    private Boolean satisfy(V value, SingleSeriesFilterExpression filter) {
         this.value = value;
         return filter.accept(this);
     }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/RecordReader.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/RecordReader.java
@@ -164,7 +164,7 @@ public class RecordReader {
             i = res.getRowGroupIndex();
         }
         for (; i < idxs.size(); i++) {
-            logger.info("GetValuesUseFilter and idxs. RowGroupIndex is :" + idxs.get(i));
+            logger.info("GetValuesUseFilter and timeIdxs. RowGroupIndex is :" + idxs.get(i));
             int idx = idxs.get(i);
             RowGroupReader rowGroupReader = rowGroupReaderList.get(idx);
             if (!deltaObjectUID.equals(rowGroupReader.getDeltaObjectUID())) {

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/BatchReadRecordGenerator.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/BatchReadRecordGenerator.java
@@ -1,7 +1,7 @@
 package cn.edu.tsinghua.tsfile.timeseries.read.query;
 
 import cn.edu.tsinghua.tsfile.common.exception.ProcessorException;
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryIteratorDataSet.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryIteratorDataSet.java
@@ -75,17 +75,17 @@ public abstract class CrossQueryIteratorDataSet extends QueryDataSet {
             Field f;
 
             //get more fields in columns i
-            if (idxs[i] < cols[i].valueLength) {
+            if (timeIdxs[i] < cols[i].valueLength) {
                 //Get more fields from file...
             }
 
-            if (idxs[i] < cols[i].valueLength && minTime == cols[i].getTime(idxs[i])) {
+            if (timeIdxs[i] < cols[i].valueLength && minTime == cols[i].getTime(timeIdxs[i])) {
                 f = new Field(cols[i].dataType, deltaObjectIds[i], measurementIds[i]);
                 f.setNull(false);
-                putValueToField(cols[i], idxs[i], f);
-                idxs[i]++;
-                if (idxs[i] < cols[i].valueLength) {
-                    heapPut(cols[i].getTime(idxs[i]));
+                putValueToField(cols[i], timeIdxs[i], f);
+                timeIdxs[i]++;
+                if (timeIdxs[i] < cols[i].valueLength) {
+                    heapPut(cols[i].getTime(timeIdxs[i]));
                 }
             } else {
                 f = new Field(cols[i].dataType, measurementIds[i]);

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryIteratorDataSet.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryIteratorDataSet.java
@@ -20,7 +20,7 @@ public abstract class CrossQueryIteratorDataSet extends QueryDataSet {
     private boolean hasReadAll;
 
     public CrossQueryIteratorDataSet(CrossQueryTimeGenerator timeGenerator) throws IOException {
-        this.timeQueryDataSet = timeGenerator;
+        this.crossQueryTimeGenerator = timeGenerator;
         mapRet = new LinkedHashMap<>();
         hasReadAll = getMoreRecords();
         size = mapRet.size();

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryTimeGenerator.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryTimeGenerator.java
@@ -88,7 +88,7 @@ public abstract class CrossQueryTimeGenerator {
             if (v == -1) {
                 break;
             }
-            if ((timeFilter == null) || (timeFilter != null && timeFilterVisitor.satisfy(v, timeFilter))) {
+            if ((timeFilter == null) || (timeFilter != null && timeFilterVisitor.satisfyObject(v, timeFilter))) {
                 res[cnt] = v;
                 cnt++;
             }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryTimeGenerator.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/CrossQueryTimeGenerator.java
@@ -191,13 +191,7 @@ public abstract class CrossQueryTimeGenerator {
     }
 
     /**
-     * valueFilterNumber parameter is mainly used for TsFileDB.
-     * Because of the exist of <code>RecordReaderCache</code>, 
-     * we must know the occur position of the SingleSeriesFilter in CrossSeriesFilterExpression.
-     */
-
-    /**
-     * valueFilterNumber parameter is mainly used for TsFileDB.
+     * valueFilterNumber parameter is mainly used for IoTDB.
      * Because of the exist of <code>RecordReaderCache</code>,
      * we must know the occur position of the SingleSeriesFilter in CrossSeriesFilterExpression.
      *

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/DynamicOneColumnData.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/DynamicOneColumnData.java
@@ -35,11 +35,8 @@ public class DynamicOneColumnData {
 
     public boolean hasEmptyTime;
     public int emptyTimeArrayIdx;
-    private int curEmptyTimeIdx;
+    public int curEmptyTimeIdx;
     public int emptyTimeLength;
-    private int emptyValueArrayIdx;
-    private int curEmptyValueIdx;
-    public int emptyValueLength;
 
     public ArrayList<long[]> timeRet;
     public ArrayList<long[]> emptyTimeRet;
@@ -150,6 +147,7 @@ public class DynamicOneColumnData {
             this.emptyTimeRet.add(new long[CAPACITY]);
             emptyTimeArrayIdx++;
             curEmptyTimeIdx = 0;
+            // System.out.println(v + "-" + emptyTimeLength + " - " +emptyTimeArrayIdx);
         }
         (emptyTimeRet.get(emptyTimeArrayIdx))[curEmptyTimeIdx++] = v;
         emptyTimeLength++;
@@ -594,6 +592,25 @@ public class DynamicOneColumnData {
                 size -= CAPACITY;
             }
             curValueIdx = CAPACITY - size;
+        }
+    }
+
+    /**
+     * Remove the last empty time.
+     */
+    public void removeLastEmptyTime() {
+        emptyTimeLength -= 1;
+        curEmptyTimeIdx -= 1;
+
+        // curEmptyTimeIdx will never == -1
+        if (curEmptyTimeIdx == 0) {
+            if (emptyTimeArrayIdx == 0) {
+                curEmptyTimeIdx = 0;
+            } else {
+                curEmptyTimeIdx = CAPACITY;
+                emptyTimeRet.remove(emptyTimeArrayIdx);
+                emptyTimeArrayIdx -= 1;
+            }
         }
     }
 

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/IteratorQueryDataSet.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/IteratorQueryDataSet.java
@@ -1,6 +1,6 @@
 package cn.edu.tsinghua.tsfile.timeseries.read.query;
 
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 import cn.edu.tsinghua.tsfile.timeseries.read.support.Field;
 import cn.edu.tsinghua.tsfile.timeseries.read.support.RowRecord;
 import org.slf4j.Logger;

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryDataSet.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryDataSet.java
@@ -18,9 +18,17 @@ public class QueryDataSet {
     /**
      * Time Generator for Cross Query when using batching read
      **/
-    public CrossQueryTimeGenerator timeQueryDataSet;
+    public CrossQueryTimeGenerator crossQueryTimeGenerator;
+
+    /**
+     * mapRet.key stores the query path, mapRet.value stores the query result of mapRet.key
+     **/
     public LinkedHashMap<String, DynamicOneColumnData> mapRet;
-    protected BatchReadRecordGenerator batchReaderRetGenerator;
+
+    /**
+     * generator used for batch read
+     **/
+    protected BatchReadRecordGenerator batchReadGenerator;
 
     /**
      * special for save time values when processing cross getIndex
@@ -44,7 +52,6 @@ public class QueryDataSet {
 
     protected String[] deltaObjectIds;
     protected String[] measurementIds;
-
     protected HashMap<Long, Integer> timeMap; // timestamp occurs time
     protected int size;
     protected boolean ifInit = false;
@@ -217,12 +224,12 @@ public class QueryDataSet {
         }
     }
 
-    public BatchReadRecordGenerator getBatchReaderRetGenerator() {
-        return batchReaderRetGenerator;
+    public BatchReadRecordGenerator getBatchReadGenerator() {
+        return batchReadGenerator;
     }
 
-    public void setBatchReaderRetGenerator(BatchReadRecordGenerator batchReaderRetGenerator) {
-        this.batchReaderRetGenerator = batchReaderRetGenerator;
+    public void setBatchReadGenerator(BatchReadRecordGenerator batchReadGenerator) {
+        this.batchReadGenerator = batchReadGenerator;
     }
 
     public Map<String, Object> getDeltaMap() {

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryDataSet.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryDataSet.java
@@ -15,21 +15,31 @@ public class QueryDataSet {
     private static final Logger LOG = LoggerFactory.getLogger(QueryDataSet.class);
     private static final char PATH_SPLITTER = '.';
 
-    /** Time Generator for Cross Query when using batching read **/
+    /**
+     * Time Generator for Cross Query when using batching read
+     **/
     public CrossQueryTimeGenerator timeQueryDataSet;
     public LinkedHashMap<String, DynamicOneColumnData> mapRet;
     protected BatchReadRecordGenerator batchReaderRetGenerator;
 
-    /** special for save time values when processing cross getIndex **/
+    /**
+     * special for save time values when processing cross getIndex
+     **/
     protected PriorityQueue<Long> heap;
 
-    /** the content of cols equals to mapRet **/
+    /**
+     * the content of cols equals to mapRet
+     **/
     protected DynamicOneColumnData[] cols;
 
-    /** timeIdxs[i] stores the index of cols[i] **/
+    /**
+     * timeIdxs[i] stores the index of cols[i]
+     **/
     protected int[] timeIdxs;
 
-    /** emptyTimeIdxs[i] stores the empty time index of cols[i] **/
+    /**
+     * emptyTimeIdxs[i] stores the empty time index of cols[i]
+     **/
     protected int[] emptyTimeIdxs;
 
     protected String[] deltaObjectIds;
@@ -120,6 +130,9 @@ public class QueryDataSet {
 
         RowRecord record = new RowRecord(minTime, null, null);
         for (int i = 0; i < size; i++) {
+            if (i == 0) {
+                record.setDeltaObjectId(deltaObjectIds[i]);
+            }
             Field field = new Field(cols[i].dataType, deltaObjectIds[i], measurementIds[i]);
             if (timeIdxs[i] < cols[i].timeLength && minTime == cols[i].getTime(timeIdxs[i])) {
                 field.setNull(false);
@@ -135,9 +148,9 @@ public class QueryDataSet {
                 if (nextTime != Long.MAX_VALUE) {
                     heapPut(nextTime);
                 }
-            } else if (emptyTimeIdxs[i] < cols[i].emptyTimeLength && minTime == cols[i].getEmptyTime(emptyTimeIdxs[i])){
+            } else if (emptyTimeIdxs[i] < cols[i].emptyTimeLength && minTime == cols[i].getEmptyTime(emptyTimeIdxs[i])) {
                 field.setNull(true);
-                emptyTimeIdxs[i] ++;
+                emptyTimeIdxs[i]++;
                 long nextTime = Long.MAX_VALUE;
                 if (emptyTimeIdxs[i] < cols[i].emptyTimeLength) {
                     nextTime = cols[i].getEmptyTime(emptyTimeIdxs[i]);

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryDataSet.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryDataSet.java
@@ -1,7 +1,6 @@
 package cn.edu.tsinghua.tsfile.timeseries.read.query;
 
 import cn.edu.tsinghua.tsfile.common.exception.UnSupportedDataTypeException;
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
 import cn.edu.tsinghua.tsfile.timeseries.read.support.Field;
 import cn.edu.tsinghua.tsfile.timeseries.read.support.RowRecord;
 import org.slf4j.Logger;
@@ -12,19 +11,27 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.PriorityQueue;
 
-
 public class QueryDataSet {
     private static final Logger LOG = LoggerFactory.getLogger(QueryDataSet.class);
     private static final char PATH_SPLITTER = '.';
 
-    // Time Generator for Cross Query when using batching read
+    /** Time Generator for Cross Query when using batching read **/
     public CrossQueryTimeGenerator timeQueryDataSet;
     public LinkedHashMap<String, DynamicOneColumnData> mapRet;
     protected BatchReadRecordGenerator batchReaderRetGenerator;
 
-    protected PriorityQueue<Long> heap; // special for save time values when processing cross getIndex
-    protected DynamicOneColumnData[] cols; // the content of cols equals to mapRet
-    protected int[] idxs; // idxs[i] stores the curIdx of cols[i]
+    /** special for save time values when processing cross getIndex **/
+    protected PriorityQueue<Long> heap;
+
+    /** the content of cols equals to mapRet **/
+    protected DynamicOneColumnData[] cols;
+
+    /** timeIdxs[i] stores the index of cols[i] **/
+    protected int[] timeIdxs;
+
+    /** emptyTimeIdxs[i] stores the empty time index of cols[i] **/
+    protected int[] emptyTimeIdxs;
+
     protected String[] deltaObjectIds;
     protected String[] measurementIds;
 
@@ -32,7 +39,7 @@ public class QueryDataSet {
     protected int size;
     protected boolean ifInit = false;
     protected RowRecord currentRecord = null;
-    private Map<String, Object> deltaMap; // this variable is used for TsFileDb
+    private Map<String, Object> deltaMap; // this variable is used for IoTDb
 
     public QueryDataSet() {
         mapRet = new LinkedHashMap<>();
@@ -46,7 +53,8 @@ public class QueryDataSet {
             cols = new DynamicOneColumnData[size];
             deltaObjectIds = new String[size];
             measurementIds = new String[size];
-            idxs = new int[size];
+            timeIdxs = new int[size];
+            emptyTimeIdxs = new int[size];
             timeMap = new HashMap<>();
         } else {
             LOG.error("QueryDataSet init row record occurs error! the size of ret is 0.");
@@ -58,10 +66,18 @@ public class QueryDataSet {
             cols[i] = mapRet.get(key);
             deltaObjectIds[i] = key.substring(0, key.lastIndexOf(PATH_SPLITTER));
             measurementIds[i] = key.substring(key.lastIndexOf(PATH_SPLITTER) + 1);
-            idxs[i] = 0;
+            timeIdxs[i] = 0;
+            emptyTimeIdxs[i] = 0;
 
-            if (cols[i] != null && (cols[i].valueLength > 0 || cols[i].timeLength > 0)) {
-                heapPut(cols[i].getTime(0));
+            if (cols[i] != null && (cols[i].valueLength > 0 || cols[i].timeLength > 0 || cols[i].emptyTimeLength > 0)) {
+                long minTime = Long.MAX_VALUE;
+                if (cols[i].timeLength > 0) {
+                    minTime = cols[i].getTime(0);
+                }
+                if (cols[i].emptyTimeLength > 0) {
+                    minTime = Math.min(minTime, cols[i].getEmptyTime(0));
+                }
+                heapPut(minTime);
             }
             i++;
         }
@@ -102,28 +118,42 @@ public class QueryDataSet {
             return null;
         }
 
-        RowRecord r = new RowRecord(minTime, null, null);
+        RowRecord record = new RowRecord(minTime, null, null);
         for (int i = 0; i < size; i++) {
-            if (i == 0) {
-                r.setDeltaObjectId(deltaObjectIds[i]);
-            }
-            Field f = new Field(cols[i].dataType, deltaObjectIds[i], measurementIds[i]);
-
-            if (idxs[i] < cols[i].valueLength && minTime == cols[i].getTime(idxs[i])) {
-                // f = new Field(cols[i].dataType, deltaObjectIds[i], measurementIds[i]);
-                f.setNull(false);
-                putValueToField(cols[i], idxs[i], f);
-                idxs[i]++;
-                if (idxs[i] < cols[i].valueLength) {
-                    heapPut(cols[i].getTime(idxs[i]));
+            Field field = new Field(cols[i].dataType, deltaObjectIds[i], measurementIds[i]);
+            if (timeIdxs[i] < cols[i].timeLength && minTime == cols[i].getTime(timeIdxs[i])) {
+                field.setNull(false);
+                putValueToField(cols[i], timeIdxs[i], field);
+                timeIdxs[i]++;
+                long nextTime = Long.MAX_VALUE;
+                if (timeIdxs[i] < cols[i].timeLength) {
+                    nextTime = cols[i].getTime(timeIdxs[i]);
+                }
+                if (emptyTimeIdxs[i] < cols[i].emptyTimeLength) {
+                    nextTime = Math.min(nextTime, cols[i].getEmptyTime(emptyTimeIdxs[i]));
+                }
+                if (nextTime != Long.MAX_VALUE) {
+                    heapPut(nextTime);
+                }
+            } else if (emptyTimeIdxs[i] < cols[i].emptyTimeLength && minTime == cols[i].getEmptyTime(emptyTimeIdxs[i])){
+                field.setNull(true);
+                emptyTimeIdxs[i] ++;
+                long nextTime = Long.MAX_VALUE;
+                if (emptyTimeIdxs[i] < cols[i].emptyTimeLength) {
+                    nextTime = cols[i].getEmptyTime(emptyTimeIdxs[i]);
+                }
+                if (timeIdxs[i] < cols[i].timeLength) {
+                    nextTime = Math.min(nextTime, cols[i].getTime(timeIdxs[i]));
+                }
+                if (nextTime != Long.MAX_VALUE) {
+                    heapPut(nextTime);
                 }
             } else {
-                // f = new Field(cols[i].dataType, measurementIds[i]);
-                f.setNull(true);
+                field.setNull(true);
             }
-            r.addField(f);
+            record.addField(field);
         }
-        return r;
+        return record;
     }
 
     public boolean next() {

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryEngine.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryEngine.java
@@ -12,7 +12,7 @@ import cn.edu.tsinghua.tsfile.timeseries.read.TsRandomAccessLocalFileReader;
 import cn.edu.tsinghua.tsfile.timeseries.read.RecordReader;
 import cn.edu.tsinghua.tsfile.timeseries.read.RowGroupReader;
 import cn.edu.tsinghua.tsfile.timeseries.read.management.SeriesSchema;
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryEngine.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/query/QueryEngine.java
@@ -204,7 +204,7 @@ public class QueryEngine {
             @Override
             public boolean getMoreRecords() throws IOException {
                 try {
-                    long[] timeRet = timeQueryDataSet.generateTimes();
+                    long[] timeRet = crossQueryTimeGenerator.generateTimes();
                     if (timeRet.length == 0) {
                         return true;
                     }
@@ -237,7 +237,7 @@ public class QueryEngine {
             @Override
             public boolean getMoreRecords() throws IOException {
                 try {
-                    long[] timeRet = timeQueryDataSet.generateTimes();
+                    long[] timeRet = crossQueryTimeGenerator.generateTimes();
                     if (timeRet.length == 0) {
                         return true;
                     }

--- a/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/support/Path.java
+++ b/src/main/java/cn/edu/tsinghua/tsfile/timeseries/read/support/Path.java
@@ -1,4 +1,4 @@
-package cn.edu.tsinghua.tsfile.timeseries.read.qp;
+package cn.edu.tsinghua.tsfile.timeseries.read.support;
 
 import cn.edu.tsinghua.tsfile.common.constant.SystemConstant;
 import cn.edu.tsinghua.tsfile.timeseries.utils.StringContainer;

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/TsFileReadTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/TsFileReadTest.java
@@ -5,7 +5,7 @@ import cn.edu.tsinghua.tsfile.timeseries.filter.definition.FilterExpression;
 import cn.edu.tsinghua.tsfile.timeseries.filter.definition.FilterFactory;
 import cn.edu.tsinghua.tsfile.timeseries.filter.definition.filterseries.FilterSeriesType;
 import cn.edu.tsinghua.tsfile.timeseries.read.TsRandomAccessLocalFileReader;
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryDataSet;
 import cn.edu.tsinghua.tsfile.timeseries.write.exception.WriteProcessException;
 

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/filter/NoFilterTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/filter/NoFilterTest.java
@@ -1,0 +1,12 @@
+package cn.edu.tsinghua.tsfile.timeseries.filter;
+
+
+import org.junit.Test;
+
+public class NoFilterTest {
+
+    @Test
+    public void noFilterTest() {
+
+    }
+}

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/DynamicOneColumnDataTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/DynamicOneColumnDataTest.java
@@ -24,4 +24,32 @@ public class DynamicOneColumnDataTest {
             Assert.assertEquals(data.getTime(i), i + 10);
         }
     }
+
+    @Test
+    public void emptyTimeTest() {
+        DynamicOneColumnData data1 = new DynamicOneColumnData(TSDataType.INT32, true, true);
+        for (int i = 1;i <= 10;i ++) {
+            if (i % 2 == 0) {
+                data1.putTime(i);
+                data1.putInt(i);
+            } else {
+                data1.putEmptyTime(i);
+            }
+        }
+
+        for (int i = 0;i < data1.valueLength;i++) {
+            Assert.assertEquals((i+1)*2, data1.getTime(i));
+            Assert.assertEquals((i+1)*2, data1.getInt(i));
+        }
+
+        for (int i = 0;i < data1.emptyTimeLength;i++) {
+            Assert.assertEquals((i+1)*2, data1.getTime(i));
+        }
+
+        DynamicOneColumnData data2 = new DynamicOneColumnData(TSDataType.INT32, true, false);
+        for (int i = 5;i <= 20;i ++) {
+            data2.putTime(i);
+            data1.putInt(i);
+        }
+    }
 }

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/DynamicOneColumnDataTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/DynamicOneColumnDataTest.java
@@ -28,7 +28,7 @@ public class DynamicOneColumnDataTest {
     @Test
     public void emptyTimeTest() {
         DynamicOneColumnData data1 = new DynamicOneColumnData(TSDataType.INT32, true, true);
-        for (int i = 1;i <= 10;i ++) {
+        for (int i = 1; i <= 10; i++) {
             if (i % 2 == 0) {
                 data1.putTime(i);
                 data1.putInt(i);
@@ -37,19 +37,63 @@ public class DynamicOneColumnDataTest {
             }
         }
 
-        for (int i = 0;i < data1.valueLength;i++) {
-            Assert.assertEquals((i+1)*2, data1.getTime(i));
-            Assert.assertEquals((i+1)*2, data1.getInt(i));
+        for (int i = 0; i < data1.valueLength; i++) {
+            Assert.assertEquals((i + 1) * 2, data1.getTime(i));
+            Assert.assertEquals((i + 1) * 2, data1.getInt(i));
         }
 
-        for (int i = 0;i < data1.emptyTimeLength;i++) {
-            Assert.assertEquals((i+1)*2, data1.getTime(i));
+        for (int i = 0; i < data1.emptyTimeLength; i++) {
+            Assert.assertEquals((i + 1) * 2, data1.getTime(i));
         }
 
         DynamicOneColumnData data2 = new DynamicOneColumnData(TSDataType.INT32, true, false);
-        for (int i = 5;i <= 20;i ++) {
+        for (int i = 5; i <= 20; i++) {
             data2.putTime(i);
             data1.putInt(i);
         }
+    }
+
+    @Test
+    public void removeLastEmptyTimeTest() {
+        DynamicOneColumnData data = new DynamicOneColumnData(TSDataType.INT32, true, true);
+        data.putEmptyTime(10);
+        Assert.assertEquals(1, data.emptyTimeLength);
+        Assert.assertEquals(10, data.getEmptyTime(0));
+
+        data.removeLastEmptyTime();
+        Assert.assertEquals(0, data.emptyTimeLength);
+        for (int i = 1; i <= 10; i++) {
+            data.putEmptyTime(i * 10);
+        }
+        Assert.assertEquals(10, data.emptyTimeLength);
+        for (int i = 0; i < data.emptyTimeLength; i++) {
+            Assert.assertEquals((i + 1) * 10, data.getEmptyTime(i));
+        }
+
+        data.clearData();
+        for (int i = 1; i <= 10001; i++) {
+            data.putEmptyTime(i);
+        }
+        for (int i = 0; i < data.emptyTimeLength; i++) {
+            Assert.assertEquals(i + 1, data.getEmptyTime(i));
+        }
+        Assert.assertEquals(10001, data.emptyTimeLength);
+        Assert.assertEquals(10, data.emptyTimeArrayIdx);
+        Assert.assertEquals(1, data.curEmptyTimeIdx);
+
+        data.removeLastEmptyTime();
+        data.removeLastEmptyTime();
+        for (int i = 0; i < data.emptyTimeLength; i++) {
+            // System.out.println(i+1 + " " + data.getEmptyTime(i));
+            Assert.assertEquals(i + 1, data.getEmptyTime(i));
+        }
+        data.putEmptyTime(20000);
+        Assert.assertEquals(9, data.emptyTimeArrayIdx);
+        Assert.assertEquals(1000, data.curEmptyTimeIdx);
+        // System.out.println(data.emptyTimeArrayIdx + " " + data.curEmptyTimeIdx);
+        for (int i = 0; i < data.emptyTimeLength - 1; i++) {
+            Assert.assertEquals(i + 1, data.getEmptyTime(i));
+        }
+        Assert.assertEquals(20000, data.getEmptyTime(data.emptyTimeLength - 1));
     }
 }

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/QueryDataSetTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/QueryDataSetTest.java
@@ -1,0 +1,63 @@
+package cn.edu.tsinghua.tsfile.timeseries.read;
+
+
+import cn.edu.tsinghua.tsfile.file.metadata.enums.TSDataType;
+import cn.edu.tsinghua.tsfile.timeseries.read.query.DynamicOneColumnData;
+import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryDataSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueryDataSetTest {
+
+    @Test
+    public void emptyQueryDataTest() {
+        String[] ret = new String[]{
+                "1	null	null",
+                "2	2	null",
+                "3	null	null",
+                "4	4	null",
+                "5	null	5.0",
+                "6	6	6.0",
+                "7	null	7.0",
+                "8	8	8.0",
+                "9	null	9.0",
+                "10	10	10.0",
+                "11	null	11.0",
+                "12	null	12.0",
+                "13	null	13.0",
+                "14	null	14.0",
+                "15	null	15.0",
+                "16	null	16.0",
+                "17	null	17.0",
+                "18	null	18.0",
+                "19	null	19.0",
+                "20	null	20.0"
+        };
+        DynamicOneColumnData data1 = new DynamicOneColumnData(TSDataType.INT32, true, true);
+        for (int i = 1; i <= 10; i++) {
+            if (i % 2 == 0) {
+                data1.putTime(i);
+                data1.putInt(i);
+            } else {
+                data1.putEmptyTime(i);
+            }
+        }
+
+        DynamicOneColumnData data2 = new DynamicOneColumnData(TSDataType.FLOAT, true, false);
+        for (int i = 5; i <= 20; i++) {
+            data2.putTime(i);
+            data2.putFloat(i);
+        }
+
+        QueryDataSet queryDataSet = new QueryDataSet();
+        queryDataSet.mapRet.put("d1.s1", data1);
+        queryDataSet.mapRet.put("d1.s2", data2);
+
+        int cnt = 0;
+        while (queryDataSet.hasNextRecord()) {
+            Assert.assertEquals(ret[cnt], queryDataSet.getNextRecord().toString());
+            cnt ++;
+            // System.out.println(queryDataSet.getNextRecord());
+        }
+    }
+}

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/QueryEngineTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/QueryEngineTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import cn.edu.tsinghua.tsfile.common.utils.ITsRandomAccessFileReader;
 import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryEngine;
-import cn.edu.tsinghua.tsfile.timeseries.read.qp.Path;
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 import cn.edu.tsinghua.tsfile.timeseries.write.exception.WriteProcessException;
 import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryConfig;
 import cn.edu.tsinghua.tsfile.timeseries.read.query.QueryDataSet;

--- a/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/qp/PathTest.java
+++ b/src/test/java/cn/edu/tsinghua/tsfile/timeseries/read/qp/PathTest.java
@@ -1,5 +1,6 @@
 package cn.edu.tsinghua.tsfile.timeseries.read.qp;
 
+import cn.edu.tsinghua.tsfile.timeseries.read.support.Path;
 import org.junit.Test;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
major modification
(1) read result could support empty value currently, add ```emptyTimeList``` in ```DynamicOneColumnData```
(2) modify the ```getNextRecord``` logic in ```QueryDataSet``` to adjust the logic of empty time list.